### PR TITLE
SCRUM-23-Filter-Tasks-Backend

### DIFF
--- a/src/main/java/com/_108287/api/controller/TaskController.java
+++ b/src/main/java/com/_108287/api/controller/TaskController.java
@@ -4,6 +4,7 @@ import com._108287.api.dto.CreateRequestTaskDTO;
 import com._108287.api.dto.ResponseTaskDTO;
 import com._108287.api.dto.UpdateRequestTaskDTO;
 import com._108287.api.entities.MyUserDetails;
+import com._108287.api.entities.TaskCompletionStatus;
 import com._108287.api.service.TaskService;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
@@ -59,8 +60,9 @@ public class TaskController {
   public ResponseEntity<List<ResponseTaskDTO>> getTasks(
     @AuthenticationPrincipal MyUserDetails userDetails,
     Sort sort,
-    @RequestParam(required = false) String category
-  ) {
+    @RequestParam(required = false) String category,
+    @RequestParam(required = false) TaskCompletionStatus completionStatus
+    ) {
     if (sort.isUnsorted()) {
       // sort not passed in api call (sort object is never null)
       sort = Sort.by(
@@ -74,7 +76,8 @@ public class TaskController {
       taskService.getTasksBySubSortedAndFiltered(
         userDetails.getUsername(),
         sort,
-        category
+        category,
+        completionStatus
       )
     );
   }

--- a/src/main/java/com/_108287/api/controller/TaskController.java
+++ b/src/main/java/com/_108287/api/controller/TaskController.java
@@ -4,7 +4,6 @@ import com._108287.api.dto.CreateRequestTaskDTO;
 import com._108287.api.dto.ResponseTaskDTO;
 import com._108287.api.dto.UpdateRequestTaskDTO;
 import com._108287.api.entities.MyUserDetails;
-import com._108287.api.entities.TaskCompletionStatus;
 import com._108287.api.service.TaskService;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
@@ -60,8 +59,7 @@ public class TaskController {
   public ResponseEntity<List<ResponseTaskDTO>> getTasks(
     @AuthenticationPrincipal MyUserDetails userDetails,
     Sort sort,
-    @RequestParam(required = false) String category,
-    @RequestParam(required = false) TaskCompletionStatus completionStatus
+    @RequestParam(required = false) String category
   ) {
     if (sort.isUnsorted()) {
       // sort not passed in api call (sort object is never null)
@@ -76,10 +74,16 @@ public class TaskController {
       taskService.getTasksBySubSortedAndFiltered(
         userDetails.getUsername(),
         sort,
-        category,
-        completionStatus
+        category
       )
     );
+  }
+
+  @GetMapping("/categories")
+  public ResponseEntity<List<String>> getCategories(
+    @AuthenticationPrincipal MyUserDetails userDetails
+  ) {
+    return ResponseEntity.ok(taskService.getCategoriesBySub(userDetails.getUsername()));
   }
 
 

--- a/src/main/java/com/_108287/api/controller/TaskController.java
+++ b/src/main/java/com/_108287/api/controller/TaskController.java
@@ -4,6 +4,7 @@ import com._108287.api.dto.CreateRequestTaskDTO;
 import com._108287.api.dto.ResponseTaskDTO;
 import com._108287.api.dto.UpdateRequestTaskDTO;
 import com._108287.api.entities.MyUserDetails;
+import com._108287.api.entities.TaskCompletionStatus;
 import com._108287.api.service.TaskService;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
@@ -58,7 +59,9 @@ public class TaskController {
   @GetMapping
   public ResponseEntity<List<ResponseTaskDTO>> getTasks(
     @AuthenticationPrincipal MyUserDetails userDetails,
-    Sort sort
+    Sort sort,
+    @RequestParam(required = false) String category,
+    @RequestParam(required = false) TaskCompletionStatus completionStatus
   ) {
     if (sort.isUnsorted()) {
       // sort not passed in api call (sort object is never null)
@@ -70,9 +73,11 @@ public class TaskController {
       return ResponseEntity.badRequest().build();
     }
     return ResponseEntity.ok(
-      taskService.getTasksBySubSorted(
+      taskService.getTasksBySubSortedAndFiltered(
         userDetails.getUsername(),
-        sort
+        sort,
+        category,
+        completionStatus
       )
     );
   }

--- a/src/main/java/com/_108287/api/converter/TaskCompletionStatusConverter.java
+++ b/src/main/java/com/_108287/api/converter/TaskCompletionStatusConverter.java
@@ -1,0 +1,21 @@
+package com._108287.api.converter;
+
+import com._108287.api.entities.TaskCompletionStatus;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TaskCompletionStatusConverter implements Converter<String, TaskCompletionStatus> {
+
+  @Override
+  public TaskCompletionStatus convert(String source) {
+    // Convert the string to the appropriate enum value
+    return switch (source.toLowerCase()) {
+      case "to_do" -> TaskCompletionStatus.TO_DO;
+      case "in_progress" -> TaskCompletionStatus.IN_PROGRESS;
+      case "done" -> TaskCompletionStatus.DONE;
+      default -> throw new IllegalArgumentException("Unknown status: " + source);
+    };
+  }
+
+}

--- a/src/main/java/com/_108287/api/repository/TaskRepository.java
+++ b/src/main/java/com/_108287/api/repository/TaskRepository.java
@@ -1,15 +1,13 @@
 package com._108287.api.repository;
 
 import com._108287.api.entities.Task;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface TaskRepository extends JpaRepository<Task, Long> {
+public interface TaskRepository extends JpaRepository<Task, Long>, JpaSpecificationExecutor<Task> {
   Optional<Task> findByIdAndSub(Long id, String sub);
-  List<Task> findBySub(String sub, Sort sort);
 }

--- a/src/main/java/com/_108287/api/repository/TaskRepository.java
+++ b/src/main/java/com/_108287/api/repository/TaskRepository.java
@@ -3,11 +3,16 @@ package com._108287.api.repository;
 import com._108287.api.entities.Task;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface TaskRepository extends JpaRepository<Task, Long>, JpaSpecificationExecutor<Task> {
   Optional<Task> findByIdAndSub(Long id, String sub);
+
+  @Query("SELECT DISTINCT t.category FROM Task t WHERE t.sub = :sub")
+  List<String> findDistinctCategoriesBySub(String sub);
 }

--- a/src/main/java/com/_108287/api/service/TaskService.java
+++ b/src/main/java/com/_108287/api/service/TaskService.java
@@ -3,7 +3,6 @@ package com._108287.api.service;
 import com._108287.api.dto.CreateRequestTaskDTO;
 import com._108287.api.dto.ResponseTaskDTO;
 import com._108287.api.dto.UpdateRequestTaskDTO;
-import com._108287.api.entities.TaskCompletionStatus;
 import org.springframework.data.domain.Sort;
 
 import java.util.List;
@@ -16,6 +15,7 @@ public interface TaskService {
 
   Optional<ResponseTaskDTO> updateTask(Long id, UpdateRequestTaskDTO updateRequestTaskDTO, String sub);
   boolean taskSortFieldsExist(Sort sort);
-  List<ResponseTaskDTO> getTasksBySubSortedAndFiltered(String sub, Sort sort, String category, TaskCompletionStatus completionStatus);
+  List<ResponseTaskDTO> getTasksBySubSortedAndFiltered(String sub, Sort sort, String category);
+  List<String> getCategoriesBySub(String sub);
 
 }

--- a/src/main/java/com/_108287/api/service/TaskService.java
+++ b/src/main/java/com/_108287/api/service/TaskService.java
@@ -3,6 +3,7 @@ package com._108287.api.service;
 import com._108287.api.dto.CreateRequestTaskDTO;
 import com._108287.api.dto.ResponseTaskDTO;
 import com._108287.api.dto.UpdateRequestTaskDTO;
+import com._108287.api.entities.TaskCompletionStatus;
 import org.springframework.data.domain.Sort;
 
 import java.util.List;
@@ -15,6 +16,6 @@ public interface TaskService {
 
   Optional<ResponseTaskDTO> updateTask(Long id, UpdateRequestTaskDTO updateRequestTaskDTO, String sub);
   boolean taskSortFieldsExist(Sort sort);
-  List<ResponseTaskDTO> getTasksBySubSorted(String sub, Sort sort);
+  List<ResponseTaskDTO> getTasksBySubSortedAndFiltered(String sub, Sort sort, String category, TaskCompletionStatus completionStatus);
 
 }

--- a/src/main/java/com/_108287/api/service/TaskService.java
+++ b/src/main/java/com/_108287/api/service/TaskService.java
@@ -3,6 +3,7 @@ package com._108287.api.service;
 import com._108287.api.dto.CreateRequestTaskDTO;
 import com._108287.api.dto.ResponseTaskDTO;
 import com._108287.api.dto.UpdateRequestTaskDTO;
+import com._108287.api.entities.TaskCompletionStatus;
 import org.springframework.data.domain.Sort;
 
 import java.util.List;
@@ -15,7 +16,7 @@ public interface TaskService {
 
   Optional<ResponseTaskDTO> updateTask(Long id, UpdateRequestTaskDTO updateRequestTaskDTO, String sub);
   boolean taskSortFieldsExist(Sort sort);
-  List<ResponseTaskDTO> getTasksBySubSortedAndFiltered(String sub, Sort sort, String category);
+  List<ResponseTaskDTO> getTasksBySubSortedAndFiltered(String sub, Sort sort, String category, TaskCompletionStatus completionStatus);
   List<String> getCategoriesBySub(String sub);
 
 }

--- a/src/main/java/com/_108287/api/service/impl/ITaskService.java
+++ b/src/main/java/com/_108287/api/service/impl/ITaskService.java
@@ -4,6 +4,7 @@ import com._108287.api.dto.CreateRequestTaskDTO;
 import com._108287.api.dto.ResponseTaskDTO;
 import com._108287.api.dto.UpdateRequestTaskDTO;
 import com._108287.api.entities.Task;
+import com._108287.api.entities.TaskCompletionStatus;
 import com._108287.api.repository.TaskRepository;
 import com._108287.api.service.TaskService;
 import com._108287.api.specifications.TaskSpecification;
@@ -87,11 +88,13 @@ public class ITaskService implements TaskService {
   public List<ResponseTaskDTO> getTasksBySubSortedAndFiltered(
     String sub,
     Sort sort,
-    String category
+    String category,
+    TaskCompletionStatus completionStatus
   ) {
     return taskRepository.findAll(
       where(TaskSpecification.hasSub(sub)
-          .and(TaskSpecification.hasCategory(category))),
+          .and(TaskSpecification.hasCategory(category))
+          .and(TaskSpecification.hasCompletionStatus(completionStatus))),
       sort
       ).stream()
       .map(ResponseTaskDTO::fromTaskEntity)

--- a/src/main/java/com/_108287/api/service/impl/ITaskService.java
+++ b/src/main/java/com/_108287/api/service/impl/ITaskService.java
@@ -4,7 +4,6 @@ import com._108287.api.dto.CreateRequestTaskDTO;
 import com._108287.api.dto.ResponseTaskDTO;
 import com._108287.api.dto.UpdateRequestTaskDTO;
 import com._108287.api.entities.Task;
-import com._108287.api.entities.TaskCompletionStatus;
 import com._108287.api.repository.TaskRepository;
 import com._108287.api.service.TaskService;
 import com._108287.api.specifications.TaskSpecification;
@@ -88,17 +87,20 @@ public class ITaskService implements TaskService {
   public List<ResponseTaskDTO> getTasksBySubSortedAndFiltered(
     String sub,
     Sort sort,
-    String category,
-    TaskCompletionStatus completionStatus
+    String category
   ) {
     return taskRepository.findAll(
       where(TaskSpecification.hasSub(sub)
-          .and(TaskSpecification.hasCategory(category))
-          .and(TaskSpecification.hasCompletionStatus(completionStatus))),
+          .and(TaskSpecification.hasCategory(category))),
       sort
       ).stream()
       .map(ResponseTaskDTO::fromTaskEntity)
       .toList();
+  }
+
+  @Override
+  public List<String> getCategoriesBySub(String sub) {
+    return taskRepository.findDistinctCategoriesBySub(sub);
   }
 
 

--- a/src/main/java/com/_108287/api/service/impl/ITaskService.java
+++ b/src/main/java/com/_108287/api/service/impl/ITaskService.java
@@ -4,8 +4,10 @@ import com._108287.api.dto.CreateRequestTaskDTO;
 import com._108287.api.dto.ResponseTaskDTO;
 import com._108287.api.dto.UpdateRequestTaskDTO;
 import com._108287.api.entities.Task;
+import com._108287.api.entities.TaskCompletionStatus;
 import com._108287.api.repository.TaskRepository;
 import com._108287.api.service.TaskService;
+import com._108287.api.specifications.TaskSpecification;
 import com._108287.api.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,6 +25,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static org.springframework.data.jpa.domain.Specification.where;
 
 @Service
 public class ITaskService implements TaskService {
@@ -81,9 +85,18 @@ public class ITaskService implements TaskService {
   }
 
   @Override
-  public List<ResponseTaskDTO> getTasksBySubSorted(String sub, Sort sort) {
-    return taskRepository.findBySub(sub, sort)
-      .stream()
+  public List<ResponseTaskDTO> getTasksBySubSortedAndFiltered(
+    String sub,
+    Sort sort,
+    String category,
+    TaskCompletionStatus completionStatus
+  ) {
+    return taskRepository.findAll(
+      where(TaskSpecification.hasSub(sub)
+          .and(TaskSpecification.hasCategory(category))
+          .and(TaskSpecification.hasCompletionStatus(completionStatus))),
+      sort
+      ).stream()
       .map(ResponseTaskDTO::fromTaskEntity)
       .toList();
   }

--- a/src/main/java/com/_108287/api/specifications/TaskSpecification.java
+++ b/src/main/java/com/_108287/api/specifications/TaskSpecification.java
@@ -1,7 +1,6 @@
 package com._108287.api.specifications;
 
 import com._108287.api.entities.Task;
-import com._108287.api.entities.TaskCompletionStatus;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Root;
@@ -26,15 +25,6 @@ public class TaskSpecification {
         return cb.conjunction();
       }
       return cb.equal(root.get("category"), category);
-    };
-  }
-
-  public static Specification<Task> hasCompletionStatus(TaskCompletionStatus completionStatus) {
-    return (Root<Task> root, CriteriaQuery<?> query, CriteriaBuilder cb) -> {
-      if (completionStatus == null) {
-        return cb.conjunction();
-      }
-      return cb.equal(root.get("completionStatus"), completionStatus);
     };
   }
 

--- a/src/main/java/com/_108287/api/specifications/TaskSpecification.java
+++ b/src/main/java/com/_108287/api/specifications/TaskSpecification.java
@@ -1,6 +1,7 @@
 package com._108287.api.specifications;
 
 import com._108287.api.entities.Task;
+import com._108287.api.entities.TaskCompletionStatus;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Root;
@@ -25,6 +26,15 @@ public class TaskSpecification {
         return cb.conjunction();
       }
       return cb.equal(root.get("category"), category);
+    };
+  }
+
+  public static Specification<Task> hasCompletionStatus(TaskCompletionStatus completionStatus) {
+    return (Root<Task> root, CriteriaQuery<?> query, CriteriaBuilder cb) -> {
+      if (completionStatus == null) {
+        return cb.conjunction();
+      }
+      return cb.equal(root.get("completionStatus"), completionStatus);
     };
   }
 

--- a/src/main/java/com/_108287/api/specifications/TaskSpecification.java
+++ b/src/main/java/com/_108287/api/specifications/TaskSpecification.java
@@ -1,0 +1,41 @@
+package com._108287.api.specifications;
+
+import com._108287.api.entities.Task;
+import com._108287.api.entities.TaskCompletionStatus;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
+import org.springframework.data.jpa.domain.Specification;
+
+public class TaskSpecification {
+
+  private TaskSpecification() { }
+
+  public static Specification<Task> hasSub(String sub) {
+    return (Root<Task> root, CriteriaQuery<?> query, CriteriaBuilder cb) -> {
+      if (sub == null) {
+        throw new IllegalArgumentException("sub cannot be null");
+      }
+      return cb.equal(root.get("sub"), sub);
+    };
+  }
+
+  public static Specification<Task> hasCategory(String category) {
+    return (Root<Task> root, CriteriaQuery<?> query, CriteriaBuilder cb) -> {
+      if (category == null) {
+        return cb.conjunction();
+      }
+      return cb.equal(root.get("category"), category);
+    };
+  }
+
+  public static Specification<Task> hasCompletionStatus(TaskCompletionStatus completionStatus) {
+    return (Root<Task> root, CriteriaQuery<?> query, CriteriaBuilder cb) -> {
+      if (completionStatus == null) {
+        return cb.conjunction();
+      }
+      return cb.equal(root.get("completionStatus"), completionStatus);
+    };
+  }
+
+}


### PR DESCRIPTION
Include in get tasks endpoint the following optional parameters
- Category
- Completion Status

Included specifications to be able to filter by multiple parameters at once. Created 3 specifications:
- hasSub (which throws exception if sub doesn't exist)
- hasCategory (if category isn't passed return conjunction)
- hasCompletionStatus (if completion status isn't passed return conjunction)